### PR TITLE
Add OpenAI-compatible provider and new Garmin page support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
-  "name": "openai-garmin-workout",
+  "name": "prompt-garmin-workout",
   "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "openai-garmin-workout",
+      "name": "prompt-garmin-workout",
       "version": "1.0.3",
       "license": "MIT",
-      "dependencies": {
-        "openai": "^5.23.1"
-      },
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.3.0",
         "@eslint/js": "^9.39.2",
@@ -6470,27 +6467,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/openai": {
-      "version": "5.23.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.23.1.tgz",
-      "integrity": "sha512-APxMtm5mln4jhKhAr0d5zP9lNsClx4QwJtg8RUvYSSyxYCTHLNJnLEcSHbJ6t0ori8Pbr9HZGfcPJ7LEy73rvQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,5 @@
     "nock": "^14.0.10",
     "prettier": "^3.8.1",
     "vite": "^7.3.1"
-  },
-  "dependencies": {
-    "openai": "^5.23.1"
   }
 }

--- a/popup.html
+++ b/popup.html
@@ -15,16 +15,27 @@
       <div class="section">
         <div class="section-title">
           <label for="apiKey">OpenAI API Key:</label>
-          <a href="https://platform.openai.com/api-keys" target="_blank" class="link">how to get a key</a>
+          <a href="https://platform.openai.com/api-keys" target="_blank" class="link"
+            >how to get a key</a
+          >
         </div>
 
-        <input type="password" id="apiKey" placeholder="Enter your OpenAI API key">
+        <input type="password" id="apiKey" placeholder="Enter your OpenAI API key" />
+      </div>
+
+      <div class="section">
+        <div class="section-title">
+          <label for="baseUrl">API Base URL:</label>
+          <span class="hint">OpenAI compatible</span>
+        </div>
+
+        <input type="url" id="baseUrl" placeholder="https://api.openai.com/v1" />
       </div>
 
       <div class="section">
         <div class="section-title">
           <label for="modelSelect">Select OpenAI Model:</label>
-          <a href="https://platform.openai.com/docs/models" target="_blank" class="link">learn more</a>
+          <button id="detectModels" class="link-button" type="button">detect models</button>
         </div>
 
         <select id="modelSelect">
@@ -34,6 +45,12 @@
           <option value="o1-mini">O1 Mini</option>
           <option value="gpt-3.5-turbo">GPT-3.5 Turbo</option>
         </select>
+
+        <input
+          type="text"
+          id="customModel"
+          placeholder="Or enter any model name, e.g. gpt-4.1-mini"
+        />
       </div>
 
       <div class="button-container">

--- a/popup.html
+++ b/popup.html
@@ -14,13 +14,13 @@
 
       <div class="section">
         <div class="section-title">
-          <label for="apiKey">OpenAI API Key:</label>
+          <label for="apiKey">API Key:</label>
           <a href="https://platform.openai.com/api-keys" target="_blank" class="link"
             >how to get a key</a
           >
         </div>
 
-        <input type="password" id="apiKey" placeholder="Enter your OpenAI API key" />
+        <input type="password" id="apiKey" placeholder="Enter your API key" />
       </div>
 
       <div class="section">
@@ -34,7 +34,7 @@
 
       <div class="section">
         <div class="section-title">
-          <label for="modelSelect">Select OpenAI Model:</label>
+          <label for="modelSelect">Model:</label>
           <button id="detectModels" class="link-button" type="button">detect models</button>
         </div>
 

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,13 +1,15 @@
 import { RUNTIME_MESSAGES, ERRORS } from '../lib/constants.js'
+import { fetchAvailableModels } from '../lib/openaiCompatibleApi.js'
 import { generateWorkout } from '../lib/openai.js'
 
 function getOpenAISettings() {
   return new Promise((resolve, reject) => {
-    chrome.storage.local.get(['openaiApiKey', 'openaiModel'], (result) => {
+    chrome.storage.local.get(['openaiApiKey', 'openaiModel', 'openaiBaseUrl'], (result) => {
       if (result.openaiApiKey && result.openaiModel) {
         resolve({
           apiKey: result.openaiApiKey,
           model: result.openaiModel,
+          baseUrl: result.openaiBaseUrl,
         })
       } else {
         reject(new ERRORS.MissingOpenAISettingsError())
@@ -20,7 +22,7 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
   if (request.type === RUNTIME_MESSAGES.generateWorkout) {
     console.log('[OGW] => Attempting to generate workout...')
     getOpenAISettings()
-      .then(({ apiKey, model }) => generateWorkout(apiKey, model, request.prompt))
+      .then(({ apiKey, model, baseUrl }) => generateWorkout(apiKey, model, request.prompt, baseUrl))
       .then((workout) => sendResponse({ type: RUNTIME_MESSAGES.generateWorkout, workout }))
       .catch((error) => {
         console.error('[OGW] => Error generating workout:', error)
@@ -29,12 +31,20 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
           chrome.action.openPopup()
           sendResponse({ type: RUNTIME_MESSAGES.noAPIKey })
         } else if (error instanceof ERRORS.WorkoutGenerationError) {
-          sendResponse({ type: RUNTIME_MESSAGES.error, message: error.message })
+          sendResponse({ type: RUNTIME_MESSAGES.error, message: `AI generation failed: ${error.message}` })
         } else {
           sendResponse({ type: RUNTIME_MESSAGES.error })
         }
       })
     return true
   }
+
+  if (request.type === RUNTIME_MESSAGES.detectModels) {
+    fetchAvailableModels(request.apiKey, request.baseUrl)
+      .then((models) => sendResponse({ type: RUNTIME_MESSAGES.detectModels, models }))
+      .catch((error) => sendResponse({ type: RUNTIME_MESSAGES.error, message: error.message }))
+    return true
+  }
+
   console.error('[OGW] => Unknown message type:', request.type)
 })

--- a/src/contentScript/elements.css
+++ b/src/contentScript/elements.css
@@ -31,7 +31,7 @@
 .ogw-modal-content {
   background-color: var(--modal-background);
   margin: 5% auto;
-  padding: 2.0rem;
+  padding: 2rem;
   border: 1px solid #888;
   width: 90%;
   max-width: 600px;
@@ -108,7 +108,7 @@
   left: -50%;
   width: 200%;
   height: 200%;
-  background: radial-gradient(circle, rgba(255,255,255,0.3) 0%, rgba(255,255,255,0) 80%);
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0) 80%);
   transform: scale(0);
   transition: transform 0.5s ease-out;
 }
@@ -164,7 +164,9 @@
   border-radius: var(--border-radius);
   padding: 1rem;
   cursor: pointer;
-  transition: background-color var(--transition-speed), transform var(--transition-speed);
+  transition:
+    background-color var(--transition-speed),
+    transform var(--transition-speed);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -194,12 +196,19 @@ button#ogw-create-workout {
   display: inline-flex;
 }
 
+.ogw-create-workout-button {
+  margin-left: 0.75rem;
+  background-color: #111111 !important;
+  border-color: #111111 !important;
+  color: #ffffff !important;
+}
+
 .ogw-spinner {
   display: inline-block;
   width: 16px;
   height: 16px;
   margin-left: 5px;
-  border: 3px solid rgba(255,255,255,.3);
+  border: 3px solid rgba(255, 255, 255, 0.3);
   border-radius: 50%;
   border-top-color: #fff;
   animation: spin 1s ease-in-out infinite;
@@ -207,8 +216,12 @@ button#ogw-create-workout {
 }
 
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 /* Media Queries */

--- a/src/contentScript/index.js
+++ b/src/contentScript/index.js
@@ -5,6 +5,7 @@ import './elements.css'
 
 let cleanupFunction = null
 let observer = null
+let mountTimer = null
 
 function setupListeners() {
   document.addEventListener(EVENTS.indexPageReady, handleIndexPageReady)
@@ -17,6 +18,10 @@ function removeListeners() {
 }
 
 function handleIndexPageReady() {
+  if (!isWorkoutsPage()) {
+    return
+  }
+
   if (cleanupFunction) {
     console.debug('[OGW] => Cleanup listeners')
     cleanupFunction()
@@ -30,32 +35,28 @@ function handleNewPromptFired(event) {
 
 export function waitPageLoaded() {
   let MutationObserver = window.MutationObserver || window.WebKitMutationObserver
-  observer = new MutationObserver(function (mutations) {
-    var evtName = null
-    var evt = null
-    let mutation = mutations.pop()
-    let target = mutation.target
-    let isWorkoutIndexPage =
-      target.classList.contains('body-workouts-index') &&
-      mutation.oldValue.indexOf('body-workouts-index') !== -1
-
-    if (isWorkoutIndexPage) {
-      evtName = EVENTS.indexPageReady
-      console.debug('[OGW] => Workout index page is ready')
-    }
-
-    if (evtName) {
-      evt = new Event(evtName)
-      document.dispatchEvent(evt)
-    }
-  })
+  observer = new MutationObserver(scheduleMount)
 
   observer.observe(document.getElementsByTagName('body')[0], {
-    subtree: false,
+    childList: true,
+    subtree: true,
     attributes: true,
-    attributeOldValue: true,
-    attributeFilter: ['class'],
   })
+
+  scheduleMount()
+}
+
+function scheduleMount() {
+  clearTimeout(mountTimer)
+  mountTimer = setTimeout(() => {
+    if (isWorkoutsPage()) {
+      document.dispatchEvent(new Event(EVENTS.indexPageReady))
+    }
+  }, 300)
+}
+
+function isWorkoutsPage() {
+  return window.location.pathname.includes('/workouts')
 }
 
 function cleanup() {
@@ -65,6 +66,7 @@ function cleanup() {
   if (observer) {
     observer.disconnect()
   }
+  clearTimeout(mountTimer)
   removeListeners()
 }
 

--- a/src/lib/__tests__/garmin.test.js
+++ b/src/lib/__tests__/garmin.test.js
@@ -180,6 +180,34 @@ describe('makePayload Function', () => {
     expect(() => makePayload(workout)).toThrow()
   })
 
+  test('uses a non-empty instruction fallback when stepDescription is missing', () => {
+    const workout = {
+      name: 'Instruction Fallback Workout',
+      type: 'cycling',
+      steps: [
+        {
+          stepName: 'Warmup',
+          stepDuration: 600,
+          stepType: 'warmup',
+        },
+        {
+          stepDuration: 1200,
+          stepType: 'interval',
+          target: {
+            type: 'power',
+            value: [260, 280],
+          },
+        },
+      ],
+    }
+
+    const payload = makePayload(workout)
+    const steps = payload.workoutSegments[0].workoutSteps
+
+    expect(steps[0].description).toBe('Warmup')
+    expect(steps[1].description).toBe('interval')
+  })
+
   test('creates payload for a workout with nested repeats', () => {
     const workout = {
       name: 'Nested Repeats Workout',

--- a/src/lib/__tests__/openai.test.js
+++ b/src/lib/__tests__/openai.test.js
@@ -433,4 +433,73 @@ describe('generateWorkout', () => {
 
     expect(workout.name).toBe('Compatible Relay')
   })
+
+  test('extracts JSON wrapped in a ```json fenced code block', async () => {
+    const workoutJson = JSON.stringify({
+      name: 'Fenced Workout',
+      type: 'running',
+      steps: [{ stepDuration: 600, stepType: 'warmup' }],
+    })
+
+    nock('https://api.openai.com')
+      .post('/v1/chat/completions')
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              content: '```json\n' + workoutJson + '\n```',
+            },
+          },
+        ],
+      })
+
+    const workout = await generateWorkout('test-api-key', 'gpt-4', '10 min warmup')
+    expect(workout.name).toBe('Fenced Workout')
+  })
+
+  test('extracts JSON wrapped in a generic fenced code block', async () => {
+    const workoutJson = JSON.stringify({
+      name: 'Fenced Generic',
+      type: 'cycling',
+      steps: [{ stepDuration: 600, stepType: 'warmup' }],
+    })
+
+    nock('https://api.openai.com')
+      .post('/v1/chat/completions')
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              content: '```\n' + workoutJson + '\n```',
+            },
+          },
+        ],
+      })
+
+    const workout = await generateWorkout('test-api-key', 'gpt-4', '10 min warmup')
+    expect(workout.name).toBe('Fenced Generic')
+  })
+
+  test('extracts JSON when the model adds prose before and after braces', async () => {
+    const workoutJson = JSON.stringify({
+      name: 'Prose Wrapped',
+      type: 'running',
+      steps: [{ stepDuration: 600, stepType: 'warmup' }],
+    })
+
+    nock('https://api.openai.com')
+      .post('/v1/chat/completions')
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              content: `Here is the workout you requested:\n\n${workoutJson}\n\nLet me know if you want to tweak anything.`,
+            },
+          },
+        ],
+      })
+
+    const workout = await generateWorkout('test-api-key', 'gpt-4', '10 min warmup')
+    expect(workout.name).toBe('Prose Wrapped')
+  })
 })

--- a/src/lib/__tests__/openai.test.js
+++ b/src/lib/__tests__/openai.test.js
@@ -99,8 +99,15 @@ describe('generateWorkout', () => {
       },
     }
 
-    nock('https://api.openai.com').post('/v1/chat/completions').reply(200, mockedResponse)
-    const workout = await generateWorkout('test-api-key', description)
+    nock('https://api.openai.com')
+      .post('/v1/chat/completions', (body) => {
+        expect(body.model).toBe('gpt-4')
+        expect(body.messages[0].role).toBe('system')
+        expect(body.messages[1].content).toContain('Long Run.')
+        return true
+      })
+      .reply(200, mockedResponse)
+    const workout = await generateWorkout('test-api-key', 'gpt-4', description)
 
     expect(workout).toEqual({
       name: 'Long Run',
@@ -177,7 +184,7 @@ describe('generateWorkout', () => {
         },
       })
 
-    await expect(generateWorkout('test-api-key', description)).rejects.toThrow()
+    await expect(generateWorkout('test-api-key', 'gpt-4', description)).rejects.toThrow()
   })
 
   test('throws error when response is invalid JSON', async () => {
@@ -202,8 +209,228 @@ describe('generateWorkout', () => {
 
     nock('https://api.openai.com').post('/v1/chat/completions').reply(200, mockedResponse)
 
-    await expect(generateWorkout('test-api-key', description)).rejects.toThrow(
+    await expect(generateWorkout('test-api-key', 'gpt-4', description)).rejects.toThrow(
       'Invalid JSON response from OpenAI.',
     )
+  })
+
+  test('uses a custom OpenAI-compatible base URL', async () => {
+    const description = '30 minutes easy'
+    const mockedResponse = {
+      id: 'chatcmpl-mocked',
+      object: 'chat.completion',
+      created: 1234567890,
+      model: 'custom-model',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: JSON.stringify({
+              name: 'Easy Spin',
+              type: 'cycling',
+              steps: [
+                {
+                  stepName: 'Easy',
+                  stepDescription: 'Ride easy',
+                  stepDuration: 1800,
+                  stepType: 'interval',
+                  target: { type: 'no target' },
+                },
+              ],
+            }),
+          },
+          finish_reason: 'stop',
+        },
+      ],
+    }
+
+    nock('https://relay.example.com').post('/v1/chat/completions').reply(200, mockedResponse)
+
+    const workout = await generateWorkout(
+      'relay-api-key',
+      'custom-model',
+      description,
+      'https://relay.example.com/v1/',
+    )
+
+    expect(workout.name).toBe('Easy Spin')
+  })
+
+  test('throws a clear error when the API response has no chat completion content', async () => {
+    const description = '30 minutes easy'
+
+    nock('https://relay.example.com').post('/v1/chat/completions').reply(200, {
+      object: 'list',
+      data: [],
+    })
+
+    await expect(
+      generateWorkout('relay-api-key', 'bad-model', description, 'https://relay.example.com/v1'),
+    ).rejects.toThrow('API response did not include choices[0].message.content')
+  })
+
+  test('rejects non-HTTPS remote base URLs', async () => {
+    await expect(
+      generateWorkout(
+        'relay-api-key',
+        'custom-model',
+        '30 minutes easy',
+        'http://relay.example.com/v1',
+      ),
+    ).rejects.toThrow('API Base URL must use HTTPS')
+  })
+
+  test('allows localhost HTTP base URLs for local testing', async () => {
+    nock('http://localhost:8787')
+      .post('/v1/chat/completions')
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                name: 'Local Easy',
+                type: 'running',
+                steps: [{ stepDuration: 1800, stepType: 'interval' }],
+              }),
+            },
+          },
+        ],
+      })
+
+    const workout = await generateWorkout(
+      'relay-api-key',
+      'custom-model',
+      '30 minutes easy',
+      'http://localhost:8787/v1',
+    )
+
+    expect(workout.name).toBe('Local Easy')
+  })
+
+  test('retries with a top-level instructions field when the relay requires it', async () => {
+    nock('https://relay.example.com')
+      .post('/v1/chat/completions', (body) => !body.instructions)
+      .reply(400, { error: { message: 'Instructions are required' } })
+      .post('/v1/chat/completions', (body) => {
+        expect(body.instructions).toContain('You are a fitness coach')
+        expect(body.messages[0].role).toBe('system')
+        return true
+      })
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                name: 'Instruction Relay',
+                type: 'cycling',
+                steps: [{ stepDuration: 600, stepType: 'warmup' }],
+              }),
+            },
+          },
+        ],
+      })
+
+    const workout = await generateWorkout(
+      'relay-api-key',
+      'custom-model',
+      '10 min warmup',
+      'https://relay.example.com/v1',
+    )
+
+    expect(workout.name).toBe('Instruction Relay')
+  })
+
+  test('retries without token limits when the relay rejects max token parameters', async () => {
+    nock('https://relay.example.com')
+      .post('/v1/chat/completions', (body) => body.max_tokens === 2000)
+      .reply(400, { error: { message: 'Unsupported parameter: max_output_tokens' } })
+      .post('/v1/chat/completions', (body) => body.max_tokens === undefined)
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                name: 'No Token Limit',
+                type: 'cycling',
+                steps: [{ stepDuration: 600, stepType: 'warmup' }],
+              }),
+            },
+          },
+        ],
+      })
+
+    const workout = await generateWorkout(
+      'relay-api-key',
+      'custom-model',
+      '10 min warmup',
+      'https://relay.example.com/v1',
+    )
+
+    expect(workout.name).toBe('No Token Limit')
+  })
+
+  test('retries without temperature when the relay rejects it', async () => {
+    nock('https://relay.example.com')
+      .post('/v1/chat/completions', (body) => body.temperature === 0.2)
+      .reply(400, { error: { message: 'Unsupported parameter: temperature' } })
+      .post('/v1/chat/completions', (body) => body.temperature === undefined)
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                name: 'No Temperature',
+                type: 'cycling',
+                steps: [{ stepDuration: 600, stepType: 'warmup' }],
+              }),
+            },
+          },
+        ],
+      })
+
+    const workout = await generateWorkout(
+      'relay-api-key',
+      'custom-model',
+      '10 min warmup',
+      'https://relay.example.com/v1',
+    )
+
+    expect(workout.name).toBe('No Temperature')
+  })
+
+  test('can combine token-limit and instructions compatibility retries', async () => {
+    nock('https://relay.example.com')
+      .post('/v1/chat/completions', (body) => body.max_tokens === 2000 && !body.instructions)
+      .reply(400, { error: { message: 'Unsupported parameter: max_output_tokens' } })
+      .post('/v1/chat/completions', (body) => body.max_tokens === undefined && !body.instructions)
+      .reply(400, { error: { message: 'Instructions are required' } })
+      .post('/v1/chat/completions', (body) => {
+        expect(body.max_tokens).toBeUndefined()
+        expect(body.instructions).toContain('You are a fitness coach')
+        return true
+      })
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                name: 'Compatible Relay',
+                type: 'cycling',
+                steps: [{ stepDuration: 600, stepType: 'warmup' }],
+              }),
+            },
+          },
+        ],
+      })
+
+    const workout = await generateWorkout(
+      'relay-api-key',
+      'custom-model',
+      '10 min warmup',
+      'https://relay.example.com/v1',
+    )
+
+    expect(workout.name).toBe('Compatible Relay')
   })
 })

--- a/src/lib/__tests__/openaiCompatibleApi.test.js
+++ b/src/lib/__tests__/openaiCompatibleApi.test.js
@@ -1,0 +1,101 @@
+import nock from 'nock'
+import {
+  DEFAULT_OPENAI_BASE_URL,
+  fetchAvailableModels,
+  getBaseUrlPermissionOrigin,
+  normalizeBaseUrl,
+  parseModelsPayload,
+} from '../openaiCompatibleApi'
+
+describe('normalizeBaseUrl', () => {
+  test('returns the default base URL when input is empty', () => {
+    expect(normalizeBaseUrl('')).toBe(DEFAULT_OPENAI_BASE_URL)
+    expect(normalizeBaseUrl(undefined)).toBe(DEFAULT_OPENAI_BASE_URL)
+  })
+
+  test('strips trailing slashes and whitespace', () => {
+    expect(normalizeBaseUrl('  https://api.openai.com/v1///  ')).toBe('https://api.openai.com/v1')
+  })
+
+  test('rejects HTTP base URLs for remote hosts', () => {
+    expect(() => normalizeBaseUrl('http://relay.example.com/v1')).toThrow(/HTTPS/)
+  })
+
+  test('allows HTTP base URLs for localhost variants', () => {
+    expect(normalizeBaseUrl('http://localhost:8787/v1')).toBe('http://localhost:8787/v1')
+    expect(normalizeBaseUrl('http://127.0.0.1:8787/v1')).toBe('http://127.0.0.1:8787/v1')
+    expect(normalizeBaseUrl('http://[::1]:8787/v1')).toBe('http://[::1]:8787/v1')
+  })
+
+  test('throws when the value is not a valid URL', () => {
+    expect(() => normalizeBaseUrl('not a url')).toThrow(/valid URL/)
+  })
+})
+
+describe('getBaseUrlPermissionOrigin', () => {
+  test('returns the wildcard origin pattern for the base URL', () => {
+    expect(getBaseUrlPermissionOrigin('https://api.openai.com/v1')).toBe(
+      'https://api.openai.com/*',
+    )
+    expect(getBaseUrlPermissionOrigin('https://relay.example.com/v1/path/')).toBe(
+      'https://relay.example.com/*',
+    )
+  })
+})
+
+describe('parseModelsPayload', () => {
+  test('returns sorted, deduplicated model ids', () => {
+    const payload = {
+      data: [
+        { id: 'gpt-4o' },
+        { id: 'gpt-3.5-turbo' },
+        { id: 'gpt-4o-mini' },
+        { id: null },
+        { id: '' },
+      ],
+    }
+
+    expect(parseModelsPayload(payload)).toEqual(['gpt-3.5-turbo', 'gpt-4o', 'gpt-4o-mini'])
+  })
+
+  test('throws a helpful error when the list is empty', () => {
+    expect(() => parseModelsPayload({ data: [] })).toThrow(/No models returned/)
+    expect(() => parseModelsPayload({})).toThrow(/No models returned/)
+  })
+})
+
+describe('fetchAvailableModels', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  test('returns parsed model ids on success', async () => {
+    nock('https://api.openai.com')
+      .get('/v1/models')
+      .matchHeader('authorization', 'Bearer test-key')
+      .reply(200, {
+        data: [{ id: 'gpt-4o' }, { id: 'gpt-3.5-turbo' }],
+      })
+
+    const models = await fetchAvailableModels('test-key', 'https://api.openai.com/v1')
+    expect(models).toEqual(['gpt-3.5-turbo', 'gpt-4o'])
+  })
+
+  test('throws a useful error when the upstream returns a non-2xx', async () => {
+    nock('https://api.openai.com')
+      .get('/v1/models')
+      .reply(401, { error: { message: 'Invalid API key' } })
+
+    await expect(
+      fetchAvailableModels('bad-key', 'https://api.openai.com/v1'),
+    ).rejects.toThrow(/401.*Invalid API key/)
+  })
+
+  test('throws when the response has no models', async () => {
+    nock('https://api.openai.com').get('/v1/models').reply(200, { data: [] })
+
+    await expect(
+      fetchAvailableModels('test-key', 'https://api.openai.com/v1'),
+    ).rejects.toThrow(/No models returned/)
+  })
+})

--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -13,9 +13,24 @@ const trustedUrls = {
   },
 }
 
+const GENERATION_RESPONSE_TIMEOUT_MS = 90000
+
 export function requestWorkout(prompt) {
   const generateButton = document.querySelector(SELECTORS.plugin.submitPromptBtn)
   const errorElement = document.querySelector(SELECTORS.plugin.errorMessage)
+  let isDone = false
+  const timeoutId = setTimeout(() => {
+    if (isDone) {
+      return
+    }
+
+    isDone = true
+    showError(
+      errorElement,
+      'Generation timed out after 90 seconds. Try a faster model or shorter prompt.',
+    )
+    setButtonLoading(generateButton, false)
+  }, GENERATION_RESPONSE_TIMEOUT_MS)
 
   hideError(errorElement)
   setButtonLoading(generateButton, true)
@@ -23,9 +38,29 @@ export function requestWorkout(prompt) {
   chrome.runtime.sendMessage(
     { type: RUNTIME_MESSAGES.generateWorkout, prompt },
     async (response) => {
+      if (isDone) {
+        return
+      }
+
+      isDone = true
+      clearTimeout(timeoutId)
+
       switch (response?.type) {
         case RUNTIME_MESSAGES.generateWorkout:
-          return createWorkout(response.workout, (response) => goToWorkout(response.workoutId))
+          try {
+            return createWorkout(
+              response.workout,
+              (response) => goToWorkout(response.workoutId),
+              (error) => {
+                showError(errorElement, error.message)
+                setButtonLoading(generateButton, false)
+              },
+            )
+          } catch (error) {
+            showError(errorElement, error.message)
+            setButtonLoading(generateButton, false)
+            return
+          }
         case RUNTIME_MESSAGES.noAPIKey:
           showError(errorElement, 'Set up your OpenAI API key in extension settings to continue.')
           break
@@ -59,17 +94,36 @@ function setButtonLoading(button, isLoading) {
 }
 
 function showError(element, message) {
-  let htmlMessage = message
-  Object.values(trustedUrls).forEach(({ pattern, text }) => {
-    if (message.includes(pattern)) {
-      htmlMessage = message.replace(
-        pattern,
-        `<a href="${pattern}" target="_blank" rel="noopener noreferrer" class="ogw-error-link">${text}</a>`,
-      )
+  if (!element) {
+    return
+  }
+
+  const safeMessage = String(message || 'Something went wrong.')
+  element.textContent = ''
+
+  const trustedUrl = Object.values(trustedUrls).find(({ pattern }) => safeMessage.includes(pattern))
+  if (!trustedUrl) {
+    element.textContent = safeMessage
+    element.style.display = 'block'
+    return
+  }
+
+  const parts = safeMessage.split(trustedUrl.pattern)
+  parts.forEach((part, index) => {
+    if (part) {
+      element.appendChild(document.createTextNode(part))
+    }
+
+    if (index < parts.length - 1) {
+      const link = document.createElement('a')
+      link.href = trustedUrl.pattern
+      link.target = '_blank'
+      link.rel = 'noopener noreferrer'
+      link.className = 'ogw-error-link'
+      link.textContent = trustedUrl.text
+      element.appendChild(link)
     }
   })
-
-  element.innerHTML = htmlMessage
   element.style.display = 'block'
 }
 

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -5,13 +5,14 @@ export const EVENTS = {
 
 export const RUNTIME_MESSAGES = {
   generateWorkout: 'GenerateWorkout',
+  detectModels: 'DetectModels',
   noAPIKey: 'NoAPIKey',
   error: 'Error',
 }
 
 export const SELECTORS = {
   garminConnect: {
-    createWorkoutButton: 'button.create-workout',
+    createWorkoutButton: 'button.create-workout, button, a[role="button"]',
   },
   plugin: {
     generateWithAIButton: '#ogw-create-workout',

--- a/src/lib/elements.js
+++ b/src/lib/elements.js
@@ -1,4 +1,4 @@
-﻿import { EVENTS, SELECTORS } from './constants'
+import { EVENTS, SELECTORS } from './constants'
 /**
  * Initializes the Generate with AI button and modal.
  * @param {string} text - The text to display on the button.

--- a/src/lib/elements.js
+++ b/src/lib/elements.js
@@ -1,18 +1,17 @@
-import { EVENTS, SELECTORS } from './constants'
+﻿import { EVENTS, SELECTORS } from './constants'
 /**
  * Initializes the Generate with AI button and modal.
  * @param {string} text - The text to display on the button.
  */
 export function initGenerateWithAIButton(text = 'Generate with AI') {
-  const createWorkoutButton = document.querySelector(SELECTORS.garminConnect.createWorkoutButton)
+  const createWorkoutButton = findCreateWorkoutButton()
   if (!createWorkoutButton) {
     return
   }
 
   const existingButton = document.querySelector(SELECTORS.plugin.generateWithAIButton)
   if (existingButton) {
-    setupEventListeners(existingButton)
-    return
+    return setupEventListeners(existingButton)
   }
 
   createModal()
@@ -20,6 +19,19 @@ export function initGenerateWithAIButton(text = 'Generate with AI') {
   const cleanup = setupEventListeners(newButton)
 
   return cleanup
+}
+
+function findCreateWorkoutButton() {
+  const candidates = [...document.querySelectorAll(SELECTORS.garminConnect.createWorkoutButton)]
+  return candidates.find((element) => {
+    const text = element.textContent?.trim().toLowerCase()
+    return (
+      text === 'create workout' ||
+      text === 'create a workout' ||
+      text === '\u521b\u5efa\u8bad\u7ec3' ||
+      text === '\u5efa\u7acb\u8bad\u7ec3'
+    )
+  })
 }
 
 /**
@@ -32,21 +44,21 @@ function createModal() {
       <div class="ogw-modal-content">
         <h2 class="ogw-modal-title">Generate Workout with AI</h2>
         <textarea id="${plugin.workoutPromptInput.slice(1)}" placeholder="Describe your workout..."></textarea>
-        <button id="${plugin.submitPromptBtn.slice(1)}" class="ogw-modal-submit-button">Generate Workout</button>
+        <button id="${plugin.submitPromptBtn.slice(1)}" class="ogw-modal-submit-button" type="button">Generate Workout</button>
 
         <div id="${plugin.errorMessage.slice(1)}" class="ogw-error-message" style="display: none;"></div>
 
         <div class="ogw-example-prompts">
           <div class="${plugin.examplePrompt.slice(1)}" role="button" tabindex="0">
-            <span class="ogw-example-icon" aria-hidden="true">🏃</span>
+            <span class="ogw-example-icon" aria-hidden="true">&#127939;</span>
             <span>1 hour pace 6:00, 1 hour pace 5:00, 30 min pace 4:00</span>
           </div>
           <div class="${plugin.examplePrompt.slice(1)}" role="button" tabindex="0">
-            <span class="ogw-example-icon" aria-hidden="true">🚴</span>
+            <span class="ogw-example-icon" aria-hidden="true">&#128692;</span>
             <span>10 min warmup, 3x(20min at 280wt, 10min at 180wt)</span>
           </div>
           <div class="${plugin.examplePrompt.slice(1)}" role="button" tabindex="0">
-            <span class="ogw-example-icon" aria-hidden="true">🏊</span>
+            <span class="ogw-example-icon" aria-hidden="true">&#127946;</span>
             <span>10 min warmup of swim, 5x(1min sprint, 4min rest)</span>
           </div>
         </div>
@@ -67,11 +79,11 @@ function createModal() {
 function createButton(createWorkoutButton, text) {
   const newButton = createWorkoutButton.cloneNode(true)
   newButton.setAttribute('id', SELECTORS.plugin.generateWithAIButton.slice(1))
-  newButton.setAttribute('class', 'btn btn-form')
+  newButton.setAttribute('type', 'button')
+  newButton.classList.add('ogw-create-workout-button')
   newButton.setAttribute('aria-label', text)
   newButton.removeAttribute('disabled')
   newButton.textContent = text
-  newButton.style.backgroundColor = 'black'
   createWorkoutButton.parentElement.appendChild(newButton)
   return newButton
 }
@@ -86,17 +98,25 @@ function setupEventListeners(newButton) {
   const submitButton = document.getElementById(plugin.submitPromptBtn.slice(1))
   const textArea = document.getElementById(plugin.workoutPromptInput.slice(1))
   const examplePrompts = document.querySelectorAll(plugin.examplePrompt)
+  const errorElement = document.querySelector(plugin.errorMessage)
+
+  if (!modal || !submitButton || !textArea) {
+    return function cleanup() {}
+  }
 
   const handleNewButtonClick = (event) => {
     event.preventDefault()
     modal.style.display = 'block'
   }
 
-  const handleSubmitButtonClick = () => handleSubmit(textArea)
+  const handleSubmitButtonClick = (event) => handleSubmit(event)
 
   const handleExamplePromptClick = (prompt) => () => {
     textArea.value = prompt.children[1].textContent
+    hideError(errorElement)
   }
+
+  const handleTextAreaInput = () => hideError(errorElement)
 
   const handleWindowClick = (event) => {
     if (event.target === modal) {
@@ -112,6 +132,7 @@ function setupEventListeners(newButton) {
 
   newButton.addEventListener('click', handleNewButtonClick)
   submitButton.addEventListener('click', handleSubmitButtonClick)
+  textArea.addEventListener('input', handleTextAreaInput)
   examplePrompts.forEach((prompt) => {
     prompt.addEventListener('click', handleExamplePromptClick(prompt))
   })
@@ -122,6 +143,7 @@ function setupEventListeners(newButton) {
   return function cleanup() {
     newButton.removeEventListener('click', handleNewButtonClick)
     submitButton.removeEventListener('click', handleSubmitButtonClick)
+    textArea.removeEventListener('input', handleTextAreaInput)
     examplePrompts.forEach((prompt) => {
       prompt.removeEventListener('click', handleExamplePromptClick(prompt))
     })
@@ -132,11 +154,39 @@ function setupEventListeners(newButton) {
 
 /**
  * Handles the submit action when generating a workout.
- * @param {HTMLTextAreaElement} textArea - The textarea containing the workout prompt.
+ * @param {MouseEvent} event - The submit click event.
  */
-function handleSubmit(textArea) {
-  const result = textArea.value.trim()
-  if (result) {
-    document.dispatchEvent(new CustomEvent(EVENTS.newPromptFired, { detail: result }))
+function handleSubmit(event) {
+  event.preventDefault()
+  event.stopPropagation()
+
+  const textArea = document.querySelector(SELECTORS.plugin.workoutPromptInput)
+  const errorElement = document.querySelector(SELECTORS.plugin.errorMessage)
+  const result = textArea?.value.trim()
+
+  if (!result) {
+    showError(errorElement, 'Describe the workout first.')
+    return
   }
+
+  hideError(errorElement)
+  document.dispatchEvent(new CustomEvent(EVENTS.newPromptFired, { detail: result }))
+}
+
+function showError(element, message) {
+  if (!element) {
+    return
+  }
+
+  element.textContent = message
+  element.style.display = 'block'
+}
+
+function hideError(element) {
+  if (!element) {
+    return
+  }
+
+  element.textContent = ''
+  element.style.display = 'none'
 }

--- a/src/lib/garmin.js
+++ b/src/lib/garmin.js
@@ -1,5 +1,5 @@
-const addWorkoutEndpoint = 'https://connect.garmin.com/workout-service/workout'
-const workoutUrl = 'https://connect.garmin.com/modern/workout/'
+const addWorkoutEndpoint = 'https://connect.garmin.com/gc-api/workout-service/workout'
+const workoutsUrl = 'https://connect.garmin.com/app/workouts'
 
 export const sportTypeMapping = {
   running: { sportTypeId: 1, sportTypeKey: 'running', displayOrder: 1 },
@@ -39,9 +39,24 @@ export const distanceUnitMapping = {
 
 export const endConditionTypeMapping = {
   time: { conditionTypeId: 2, conditionTypeKey: 'time', displayOrder: 2, displayable: true },
-  distance: { conditionTypeId: 3, conditionTypeKey: 'distance', displayOrder: 3, displayable: true },
-  'lap.button': { conditionTypeId: 1, conditionTypeKey: 'lap.button', displayOrder: 1, displayable: true },
-  iterations: { conditionTypeId: 7, conditionTypeKey: 'iterations', displayOrder: 7, displayable: false },
+  distance: {
+    conditionTypeId: 3,
+    conditionTypeKey: 'distance',
+    displayOrder: 3,
+    displayable: true,
+  },
+  'lap.button': {
+    conditionTypeId: 1,
+    conditionTypeKey: 'lap.button',
+    displayOrder: 1,
+    displayable: true,
+  },
+  iterations: {
+    conditionTypeId: 7,
+    conditionTypeKey: 'iterations',
+    displayOrder: 7,
+    displayable: false,
+  },
 }
 
 /**
@@ -49,12 +64,12 @@ export const endConditionTypeMapping = {
  * These are used when estimating duration for distance steps without pace targets
  */
 const DEFAULT_PACE = {
-  running: 0.36,      // ~6:00 min/km or ~9:40 min/mile
-  cycling: 0.05,      // ~3:00 min/km or ~5:00 min/mile (12 mph)
-  swimming: 0.5,      // ~8:20 min/100m
-  walking: 0.3,       // ~5:00 min/km
-  strength: 0.36,     // Same as running
-  cardio: 0.36,       // Same as running
+  running: 0.36, // ~6:00 min/km or ~9:40 min/mile
+  cycling: 0.05, // ~3:00 min/km or ~5:00 min/mile (12 mph)
+  swimming: 0.5, // ~8:20 min/100m
+  walking: 0.3, // ~5:00 min/km
+  strength: 0.36, // Same as running
+  cardio: 0.36, // Same as running
 }
 
 /**
@@ -93,6 +108,11 @@ export function makePayload(workout) {
   payload.estimatedDurationInSecs = calculateEstimatedDuration(payload.workoutSegments)
 
   return payload
+}
+
+function getStepDescription(step) {
+  const description = step.stepDescription || step.stepName || step.stepType || 'Workout step'
+  return String(description).trim() || 'Workout step'
 }
 
 /**
@@ -134,7 +154,11 @@ function processSteps(stepsArray, stepOrder) {
  */
 function processStep(step, stepOrder) {
   // Handle both stepType and endConditionType for identifying repeat steps
-  if (step.numberOfIterations && step.steps && (step.stepType === 'repeat' || step.endConditionType === 'repeat')) {
+  if (
+    step.numberOfIterations &&
+    step.steps &&
+    (step.stepType === 'repeat' || step.endConditionType === 'repeat')
+  ) {
     return processRepeatStep(step, stepOrder)
   } else if (!step.stepType) {
     throw new Error(`Missing stepType for step: ${step.stepName || 'Unnamed Step'}`)
@@ -157,8 +181,8 @@ function processRegularStep(step, stepOrder) {
     stepOrder: stepOrder,
     stepType: stepType,
     type: 'ExecutableStepDTO',
-    description: step.stepDescription || '',
-    stepAudioNote: null
+    description: getStepDescription(step),
+    stepAudioNote: null,
   }
 
   // Process end condition (time or distance)
@@ -169,20 +193,22 @@ function processRegularStep(step, stepOrder) {
     }
 
     workoutStep.endCondition = endConditionTypeMapping.distance
-    workoutStep.endConditionValue = step.stepDistance * distanceUnit.factor  // Convert to meters
+    workoutStep.endConditionValue = step.stepDistance * distanceUnit.factor // Convert to meters
 
     // When using km for distances >= 1000m, or miles for imperial, make sure
     // the input value is preserved in the native unit rather than being converted
     if (distanceUnit.unitKey === 'km' && workoutStep.endConditionValue >= 1000) {
-      workoutStep.endConditionValue = Math.round(workoutStep.endConditionValue);
+      workoutStep.endConditionValue = Math.round(workoutStep.endConditionValue)
     } else if (distanceUnit.unitKey === 'mile') {
       // For miles, preserve the exact conversion factor
-      workoutStep.endConditionValue = step.stepDistance * 1609.344;
+      workoutStep.endConditionValue = step.stepDistance * 1609.344
     }
   } else {
     // Default to time-based
     if (typeof step.stepDuration !== 'number' || step.stepDuration <= 0) {
-      throw new Error(`Invalid or missing stepDuration for step: ${step.stepName || 'Unnamed Step'}`)
+      throw new Error(
+        `Invalid or missing stepDuration for step: ${step.stepName || 'Unnamed Step'}`,
+      )
     }
 
     workoutStep.endCondition = endConditionTypeMapping.time
@@ -197,7 +223,7 @@ function processRegularStep(step, stepOrder) {
 
   // Explicitly set targetValueUnit to null as seen in the valid payload
   if (workoutStep.targetType && workoutStep.targetType.workoutTargetTypeKey !== 'no.target') {
-    workoutStep.targetValueUnit = null;
+    workoutStep.targetValueUnit = null
   }
 
   stepOrder += 1
@@ -327,27 +353,27 @@ function convertValueToUnit(value, unit) {
  * @returns {number} - The estimated duration of the workout in seconds.
  */
 function calculateEstimatedDuration(workoutSegments) {
-  let duration = 0;
-  const sportType = workoutSegments[0]?.sportType?.sportTypeKey || 'running';
+  let duration = 0
+  const sportType = workoutSegments[0]?.sportType?.sportTypeKey || 'running'
 
   workoutSegments.forEach((segment) => {
     segment.workoutSteps.forEach((step) => {
       if (step.type === 'ExecutableStepDTO') {
         if (step.endCondition.conditionTypeKey === 'distance') {
           // For distance-based steps, estimate duration based on pace
-          duration += estimateStepDuration(step, sportType);
+          duration += estimateStepDuration(step, sportType)
         } else {
           // For time-based steps, use the step duration directly
-          duration += step.endConditionValue;
+          duration += step.endConditionValue
         }
       } else if (step.type === 'RepeatGroupDTO') {
         // Create a fake segment containing just the child steps of the repeat
-        const childStepsDuration = calculateStepsDuration(step.workoutSteps, sportType);
-        duration += step.numberOfIterations * childStepsDuration;
+        const childStepsDuration = calculateStepsDuration(step.workoutSteps, sportType)
+        duration += step.numberOfIterations * childStepsDuration
       }
-    });
-  });
-  return duration;
+    })
+  })
+  return duration
 }
 
 /**
@@ -357,22 +383,22 @@ function calculateEstimatedDuration(workoutSegments) {
  * @returns {number} - The estimated duration in seconds.
  */
 function calculateStepsDuration(steps, sportType) {
-  let duration = 0;
+  let duration = 0
 
   steps.forEach((step) => {
     if (step.type === 'ExecutableStepDTO') {
       if (step.endCondition.conditionTypeKey === 'distance') {
-        duration += estimateStepDuration(step, sportType);
+        duration += estimateStepDuration(step, sportType)
       } else {
-        duration += step.endConditionValue;
+        duration += step.endConditionValue
       }
     } else if (step.type === 'RepeatGroupDTO') {
-      const childStepsDuration = calculateStepsDuration(step.workoutSteps, sportType);
-      duration += step.numberOfIterations * childStepsDuration;
+      const childStepsDuration = calculateStepsDuration(step.workoutSteps, sportType)
+      duration += step.numberOfIterations * childStepsDuration
     }
-  });
+  })
 
-  return duration;
+  return duration
 }
 
 /**
@@ -382,43 +408,75 @@ function calculateStepsDuration(steps, sportType) {
  * @returns {number} - The estimated duration in seconds.
  */
 function estimateStepDuration(step, sportType) {
-  const distance = step.endConditionValue; // distance in meters
-  let pacePerMeter;
+  const distance = step.endConditionValue // distance in meters
+  let pacePerMeter
 
   // Check if the step has a pace target
-  if (step.targetType && step.targetType.workoutTargetTypeKey === 'pace.zone' && 
-      step.targetValueOne && step.targetValueTwo) {
+  if (
+    step.targetType &&
+    step.targetType.workoutTargetTypeKey === 'pace.zone' &&
+    step.targetValueOne &&
+    step.targetValueTwo
+  ) {
     // Use the average of min and max pace values
     // targetValueOne and targetValueTwo are in m/s, so we convert to seconds per meter
-    pacePerMeter = 2 / (step.targetValueOne + step.targetValueTwo);
-  } else if (step.targetType && step.targetType.workoutTargetTypeKey === 'speed.zone' && 
-             step.targetValueOne && step.targetValueTwo) {
+    pacePerMeter = 2 / (step.targetValueOne + step.targetValueTwo)
+  } else if (
+    step.targetType &&
+    step.targetType.workoutTargetTypeKey === 'speed.zone' &&
+    step.targetValueOne &&
+    step.targetValueTwo
+  ) {
     // If speed target, use the average speed in m/s
-    const avgSpeed = (step.targetValueOne + step.targetValueTwo) / 2;
-    pacePerMeter = 1 / avgSpeed;
+    const avgSpeed = (step.targetValueOne + step.targetValueTwo) / 2
+    pacePerMeter = 1 / avgSpeed
   } else {
     // Use default pace value based on sport type
-    pacePerMeter = DEFAULT_PACE[sportType.toLowerCase()] || DEFAULT_PACE.running;
+    pacePerMeter = DEFAULT_PACE[sportType.toLowerCase()] || DEFAULT_PACE.running
   }
 
   // Calculate estimated duration
-  return distance * pacePerMeter;
+  return distance * pacePerMeter
 }
 
-export function createWorkout(workout, callback) {
+export function createWorkout(workout, callback, errorCallback = () => {}) {
   let garminVersion = document.getElementById('garmin-connect-version')
   let xhr = new XMLHttpRequest()
+  xhr.timeout = 30000
 
   xhr.onreadystatechange = function () {
-    if (this.readyState == 4 && this.status == 200) {
-      callback(JSON.parse(xhr.response))
+    if (this.readyState !== 4) {
+      return
     }
+
+    if (this.status >= 200 && this.status < 300) {
+      try {
+        callback(JSON.parse(xhr.response))
+      } catch {
+        errorCallback(new Error('Garmin returned an invalid JSON response.'))
+      }
+      return
+    }
+
+    errorCallback(new Error(formatGarminUploadError(this.status, xhr.responseText)))
   }
 
-  let localStoredToken = window.localStorage.getItem('token')
-  let accessTokenMap = JSON.parse(localStoredToken)
-  let token = accessTokenMap.access_token
-  const payload = makePayload(workout)
+  xhr.onerror = function () {
+    errorCallback(new Error('Garmin upload failed due to a network error.'))
+  }
+
+  xhr.ontimeout = function () {
+    errorCallback(new Error('Garmin upload timed out after 30 seconds.'))
+  }
+
+  let token = getGarminAccessToken()
+  let payload
+  try {
+    payload = makePayload(workout)
+  } catch (error) {
+    errorCallback(new Error(`Could not prepare Garmin workout: ${error.message}`))
+    return
+  }
 
   console.debug('[OGW] Payload:', JSON.stringify(payload))
 
@@ -426,19 +484,67 @@ export function createWorkout(workout, callback) {
   xhr.setRequestHeader('Content-Type', 'application/json')
   xhr.setRequestHeader('Accept', 'application/json, text/javascript, */*; q=0.01')
 
-  xhr.setRequestHeader('x-app-ver', garminVersion.innerText || '4.27.1.0')
+  const csrfToken = getGarminCsrfToken()
+  if (csrfToken) {
+    xhr.setRequestHeader('connect-csrf-token', csrfToken)
+  }
+
+  xhr.setRequestHeader('x-app-ver', garminVersion?.innerText || '4.27.1.0')
   xhr.setRequestHeader('x-requested-with', 'XMLHttpRequest')
   xhr.setRequestHeader('x-lang', 'it-IT')
   xhr.setRequestHeader('nk', 'NT')
   xhr.setRequestHeader('Di-Backend', 'connectapi.garmin.com')
-  xhr.setRequestHeader('authorization', 'Bearer ' + token)
+  if (token) {
+    xhr.setRequestHeader('authorization', 'Bearer ' + token)
+  }
   xhr.withCredentials = true
 
   xhr.send(JSON.stringify(payload))
 }
 
-export function goToWorkout(id) {
-  window.location.assign(workoutUrl + id)
+function formatGarminUploadError(status, responseText) {
+  const details = parseGarminErrorMessage(responseText)
+  return `Garmin upload failed (${status}): ${details}`
+}
+
+function parseGarminErrorMessage(responseText) {
+  if (!responseText) {
+    return 'No response body returned.'
+  }
+
+  try {
+    const payload = JSON.parse(responseText)
+    return (
+      payload?.message ||
+      payload?.error?.message ||
+      payload?.errorMessage ||
+      payload?.errors?.[0]?.message ||
+      responseText
+    )
+  } catch {
+    return responseText
+  }
+}
+
+function getGarminCsrfToken() {
+  return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || null
+}
+
+function getGarminAccessToken() {
+  const localStoredToken = window.localStorage.getItem('token')
+  if (!localStoredToken) {
+    return null
+  }
+
+  try {
+    return JSON.parse(localStoredToken)?.access_token || null
+  } catch {
+    return null
+  }
+}
+
+export function goToWorkout() {
+  window.location.assign(workoutsUrl)
 }
 
 export const workoutExamples = {
@@ -600,123 +706,123 @@ export const workoutExamples = {
   },
 
   distanceBasedWorkout: {
-    name: "Distance-based Interval Workout",
-    type: "running",
+    name: 'Distance-based Interval Workout',
+    type: 'running',
     steps: [
       {
-        stepName: "Warm Up",
-        stepDescription: "Warm up with easy jogging",
-        endConditionType: "distance",
+        stepName: 'Warm Up',
+        stepDescription: 'Warm up with easy jogging',
+        endConditionType: 'distance',
         stepDistance: 1,
-        distanceUnit: "km",
-        stepType: "warmup",
+        distanceUnit: 'km',
+        stepType: 'warmup',
         target: {
-          type: "no target"
-        }
+          type: 'no target',
+        },
       },
       {
-        stepType: "repeat",
+        stepType: 'repeat',
         numberOfIterations: 5,
         steps: [
           {
-            stepName: "Fast 400m",
-            stepDescription: "Run fast for 400 meters",
-            endConditionType: "distance",
+            stepName: 'Fast 400m',
+            stepDescription: 'Run fast for 400 meters',
+            endConditionType: 'distance',
             stepDistance: 400,
-            distanceUnit: "m",
-            stepType: "interval",
+            distanceUnit: 'm',
+            stepType: 'interval',
             target: {
-              type: "pace",
+              type: 'pace',
               value: [4, 4.5],
-              unit: "min_per_km"
-            }
+              unit: 'min_per_km',
+            },
           },
           {
-            stepName: "Recovery",
-            stepDescription: "Easy jog for recovery",
-            endConditionType: "distance",
+            stepName: 'Recovery',
+            stepDescription: 'Easy jog for recovery',
+            endConditionType: 'distance',
             stepDistance: 200,
-            distanceUnit: "m",
-            stepType: "recovery",
+            distanceUnit: 'm',
+            stepType: 'recovery',
             target: {
-              type: "heart rate",
+              type: 'heart rate',
               value: [120, 130],
-              unit: "bpm"
-            }
-          }
-        ]
+              unit: 'bpm',
+            },
+          },
+        ],
       },
       {
-        stepName: "Cool Down",
-        stepDescription: "Slow jog to cool down",
-        endConditionType: "distance",
+        stepName: 'Cool Down',
+        stepDescription: 'Slow jog to cool down',
+        endConditionType: 'distance',
         stepDistance: 1,
-        distanceUnit: "km",
-        stepType: "cooldown",
+        distanceUnit: 'km',
+        stepType: 'cooldown',
         target: {
-          type: "no target"
-        }
-      }
-    ]
+          type: 'no target',
+        },
+      },
+    ],
   },
 
   mixedWorkout: {
-    name: "Mixed Time and Distance Workout",
-    type: "running",
+    name: 'Mixed Time and Distance Workout',
+    type: 'running',
     steps: [
       {
-        stepName: "Warm Up",
-        stepDescription: "Warm up with easy jogging",
-        endConditionType: "time",
+        stepName: 'Warm Up',
+        stepDescription: 'Warm up with easy jogging',
+        endConditionType: 'time',
         stepDuration: 600,
-        stepType: "warmup",
+        stepType: 'warmup',
         target: {
-          type: "heart rate",
+          type: 'heart rate',
           value: [120, 130],
-          unit: "bpm"
-        }
+          unit: 'bpm',
+        },
       },
       {
-        stepType: "repeat",
+        stepType: 'repeat',
         numberOfIterations: 3,
         steps: [
           {
-            stepName: "Mile Repeat",
-            stepDescription: "Run one mile at target pace",
-            endConditionType: "distance",
+            stepName: 'Mile Repeat',
+            stepDescription: 'Run one mile at target pace',
+            endConditionType: 'distance',
             stepDistance: 1,
-            distanceUnit: "mile",
-            stepType: "interval",
+            distanceUnit: 'mile',
+            stepType: 'interval',
             target: {
-              type: "pace",
+              type: 'pace',
               value: [4.5, 5],
-              unit: "min_per_km"
-            }
+              unit: 'min_per_km',
+            },
           },
           {
-            stepName: "Recovery",
-            stepDescription: "Recovery period",
-            endConditionType: "time",
+            stepName: 'Recovery',
+            stepDescription: 'Recovery period',
+            endConditionType: 'time',
             stepDuration: 180,
-            stepType: "recovery",
+            stepType: 'recovery',
             target: {
-              type: "heart rate",
+              type: 'heart rate',
               value: [120, 130],
-              unit: "bpm"
-            }
-          }
-        ]
+              unit: 'bpm',
+            },
+          },
+        ],
       },
       {
-        stepName: "Cool Down",
-        stepDescription: "Slow jog to cool down",
-        endConditionType: "time",
+        stepName: 'Cool Down',
+        stepDescription: 'Slow jog to cool down',
+        endConditionType: 'time',
         stepDuration: 600,
-        stepType: "cooldown",
+        stepType: 'cooldown',
         target: {
-          type: "no target"
-        }
-      }
-    ]
-  }
+          type: 'no target',
+        },
+      },
+    ],
+  },
 }

--- a/src/lib/garmin.js
+++ b/src/lib/garmin.js
@@ -1,5 +1,7 @@
 const addWorkoutEndpoint = 'https://connect.garmin.com/gc-api/workout-service/workout'
 const workoutsUrl = 'https://connect.garmin.com/app/workouts'
+const GARMIN_UPLOAD_TIMEOUT_MS = 30000
+const GARMIN_UPLOAD_TIMEOUT_SECONDS = GARMIN_UPLOAD_TIMEOUT_MS / 1000
 
 export const sportTypeMapping = {
   running: { sportTypeId: 1, sportTypeKey: 'running', displayOrder: 1 },
@@ -440,9 +442,9 @@ function estimateStepDuration(step, sportType) {
 }
 
 export function createWorkout(workout, callback, errorCallback = () => {}) {
-  let garminVersion = document.getElementById('garmin-connect-version')
-  let xhr = new XMLHttpRequest()
-  xhr.timeout = 30000
+  const garminVersion = document.getElementById('garmin-connect-version')
+  const xhr = new XMLHttpRequest()
+  xhr.timeout = GARMIN_UPLOAD_TIMEOUT_MS
 
   xhr.onreadystatechange = function () {
     if (this.readyState !== 4) {
@@ -466,10 +468,10 @@ export function createWorkout(workout, callback, errorCallback = () => {}) {
   }
 
   xhr.ontimeout = function () {
-    errorCallback(new Error('Garmin upload timed out after 30 seconds.'))
+    errorCallback(new Error(`Garmin upload timed out after ${GARMIN_UPLOAD_TIMEOUT_SECONDS} seconds.`))
   }
 
-  let token = getGarminAccessToken()
+  const token = getGarminAccessToken()
   let payload
   try {
     payload = makePayload(workout)

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -1,47 +1,184 @@
-import OpenAI from 'openai'
 import { ERRORS } from '../lib/constants.js'
+import { DEFAULT_OPENAI_BASE_URL, normalizeBaseUrl } from './openaiCompatibleApi.js'
+
+const CHAT_COMPLETION_TIMEOUT_MS = 60000
+// Compatibility retries remove optional request fields one by one when a provider rejects them.
+// The cap prevents loops while allowing instructions plus the common optional parameters to settle.
+const MAX_COMPATIBILITY_RETRIES = 6
 
 /**
  * Generates a workout based on the description.
  * @param {string} apiKey - The OpenAI API key.
  * @param {string} model - The OpenAI model to use.
  * @param {string} description - The workout description.
+ * @param {string} baseUrl - The OpenAI-compatible API base URL.
  * @returns {Promise<Object>} - The generated workout object.
  */
-export async function generateWorkout(apiKey, model, description) {
+export async function generateWorkout(
+  apiKey,
+  model,
+  description,
+  baseUrl = DEFAULT_OPENAI_BASE_URL,
+) {
   try {
     const prompt = createPrompt(description)
-    const client = new OpenAI({ apiKey })
-
-    const response = await client.chat.completions.create({
-      model,
-      messages: [{ role: 'user', content: prompt }],
-      max_tokens: 1000,
-      temperature: 0.7,
-    })
-
-    const assistantMessage = response.choices[0].message.content
+    const response = await createChatCompletion(apiKey, model, prompt, baseUrl)
+    const assistantMessage = extractAssistantMessage(response)
     return parseWorkoutResponse(assistantMessage)
   } catch (error) {
     throw new ERRORS.WorkoutGenerationError(error.message)
   }
 }
 
-function createPrompt(description) {
-  return `
-You are a fitness coach.
-Given the following workout description, create a structured JSON object that represents the workout.
-The JSON should be compatible with the makePayload function used for Garmin workouts.
+async function createChatCompletion(apiKey, model, prompt, baseUrl) {
+  const url = `${normalizeBaseUrl(baseUrl)}/chat/completions`
+  const body = createChatCompletionBody(model, prompt)
+  let lastError
 
-Workout Description:
-${description}
+  for (let attempt = 0; attempt < MAX_COMPATIBILITY_RETRIES; attempt += 1) {
+    try {
+      return await postChatCompletion(url, apiKey, body)
+    } catch (error) {
+      lastError = error
+
+      if (isInstructionsRequiredError(error) && !body.instructions) {
+        body.instructions = prompt.instructions
+        continue
+      }
+
+      const unsupportedParameter = getUnsupportedParameter(error)
+      if (unsupportedParameter && removeUnsupportedParameter(body, unsupportedParameter)) {
+        continue
+      }
+
+      throw error
+    }
+  }
+
+  throw lastError || new Error('API request failed after compatibility retries.')
+}
+
+function isInstructionsRequiredError(error) {
+  return /instructions.*required/i.test(error.message)
+}
+
+function getUnsupportedParameter(error) {
+  const match = error.message.match(/unsupported parameter:?\s*['"]?([\w.-]+)['"]?/i)
+  return match?.[1]?.toLowerCase() || null
+}
+
+function removeUnsupportedParameter(body, parameter) {
+  const parameterAliases = {
+    max_output_tokens: ['max_tokens', 'max_completion_tokens', 'max_output_tokens'],
+    max_completion_tokens: ['max_tokens', 'max_completion_tokens', 'max_output_tokens'],
+    max_tokens: ['max_tokens', 'max_completion_tokens', 'max_output_tokens'],
+    temperature: ['temperature'],
+    top_p: ['top_p'],
+    frequency_penalty: ['frequency_penalty'],
+    presence_penalty: ['presence_penalty'],
+    response_format: ['response_format'],
+    instructions: ['instructions'],
+  }
+
+  const keys = parameterAliases[parameter] || [parameter]
+  let removed = false
+
+  keys.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(body, key)) {
+      delete body[key]
+      removed = true
+    }
+  })
+
+  return removed
+}
+
+function createChatCompletionBody(model, prompt) {
+  return {
+    model,
+    messages: [
+      { role: 'system', content: prompt.instructions },
+      { role: 'user', content: prompt.userMessage },
+    ],
+    temperature: 0.2,
+    max_tokens: 2000,
+  }
+}
+
+async function postChatCompletion(url, apiKey, body) {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), CHAT_COMPLETION_TIMEOUT_MS)
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(body),
+    signal: controller.signal,
+  })
+    .catch((error) => {
+      if (error.name === 'AbortError') {
+        throw new Error('Model request timed out after 60 seconds. Try a faster model.')
+      }
+      throw error
+    })
+    .finally(() => clearTimeout(timeoutId))
+
+  const payload = await readJson(response)
+
+  if (!response.ok) {
+    throw new Error(payload?.error?.message || `API request failed with status ${response.status}`)
+  }
+
+  if (payload?.error?.message) {
+    throw new Error(payload.error.message)
+  }
+
+  return payload
+}
+
+function extractAssistantMessage(response) {
+  const content = response?.choices?.[0]?.message?.content
+
+  if (typeof content === 'string') {
+    return content
+  }
+
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => part?.text || part?.content || '')
+      .join('')
+      .trim()
+  }
+
+  throw new Error(
+    'API response did not include choices[0].message.content. Check the selected model.',
+  )
+}
+
+async function readJson(response) {
+  try {
+    return await response.json()
+  } catch {
+    throw new Error('API response was not valid JSON.')
+  }
+}
+
+function createPrompt(description) {
+  const instructions = `
+You are a fitness coach.
+Given a workout description, create a structured JSON object that represents the workout.
+The JSON should be compatible with the makePayload function used for Garmin workouts.
 
 Requirements:
 - The output must be valid JSON.
 - Use the following structure for the workout object:
 {
   "name": "Workout Name",
-  "type": "running" | "cycling" | "swimming" | "walking" | "cardio" | "strength",
+  "type": "running" | "cycling" | "swimming" | "cardio" | "strength",
   "steps": [
     {
       "stepName": "Step Name",
@@ -76,14 +213,35 @@ Constraints:
 - The step with the slowest target in the repeat should be of type "recovery" or "rest".
 - The JSON must be parsable and not include additional explanations. Do not include any formatting or comments in the JSON.
 `
+
+  return {
+    instructions,
+    userMessage: `Workout Description:\n${description}`,
+  }
 }
 
 function parseWorkoutResponse(responseText) {
-  const trimmedText = responseText.trim()
+  const trimmedText = extractJsonText(responseText)
 
   try {
     return JSON.parse(trimmedText)
   } catch {
     throw new Error('Invalid JSON response from OpenAI.')
   }
+}
+
+function extractJsonText(responseText) {
+  const trimmedText = responseText.trim()
+  const fencedMatch = trimmedText.match(/```(?:json)?\s*([\s\S]*?)```/i)
+  if (fencedMatch) {
+    return fencedMatch[1].trim()
+  }
+
+  const firstBrace = trimmedText.indexOf('{')
+  const lastBrace = trimmedText.lastIndexOf('}')
+  if (firstBrace !== -1 && lastBrace > firstBrace) {
+    return trimmedText.slice(firstBrace, lastBrace + 1)
+  }
+
+  return trimmedText
 }

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -2,9 +2,10 @@ import { ERRORS } from '../lib/constants.js'
 import { DEFAULT_OPENAI_BASE_URL, normalizeBaseUrl } from './openaiCompatibleApi.js'
 
 const CHAT_COMPLETION_TIMEOUT_MS = 60000
-// Compatibility retries remove optional request fields one by one when a provider rejects them.
-// The cap prevents loops while allowing instructions plus the common optional parameters to settle.
-const MAX_COMPATIBILITY_RETRIES = 6
+// Compatibility retries drop optional request fields one at a time when a provider rejects them.
+// Validation failures return fast, so the cap is sized to fit the popup-side 90s budget
+// (a few fast validation rejections plus one real chat-completion call).
+const MAX_COMPATIBILITY_RETRIES = 4
 
 /**
  * Generates a workout based on the description.

--- a/src/lib/openaiCompatibleApi.js
+++ b/src/lib/openaiCompatibleApi.js
@@ -1,0 +1,71 @@
+export const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1'
+
+export function normalizeBaseUrl(baseUrl) {
+  if (!baseUrl) {
+    return DEFAULT_OPENAI_BASE_URL
+  }
+
+  const normalizedBaseUrl = baseUrl.trim().replace(/\/+$/, '')
+  let parsedUrl
+  try {
+    parsedUrl = new URL(normalizedBaseUrl)
+  } catch {
+    throw new Error('API Base URL must be a valid URL.')
+  }
+
+  const isLocalhost = ['localhost', '127.0.0.1', '[::1]'].includes(parsedUrl.hostname)
+  if (parsedUrl.protocol !== 'https:' && !(parsedUrl.protocol === 'http:' && isLocalhost)) {
+    throw new Error('API Base URL must use HTTPS, except for localhost testing.')
+  }
+
+  return normalizedBaseUrl
+}
+
+export function getBaseUrlPermissionOrigin(baseUrl) {
+  return `${new URL(normalizeBaseUrl(baseUrl)).origin}/*`
+}
+
+export async function fetchAvailableModels(apiKey, baseUrl) {
+  const url = `${normalizeBaseUrl(baseUrl)}/models`
+  let response
+
+  try {
+    response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json',
+      },
+    })
+  } catch {
+    throw new Error(`Could not reach ${url}. Check the Base URL and extension permissions.`)
+  }
+
+  if (!response.ok) {
+    const message = await readErrorMessage(response)
+    throw new Error(`Could not detect models: ${response.status} ${message}`)
+  }
+
+  return parseModelsPayload(await response.json())
+}
+
+export function parseModelsPayload(payload) {
+  const models = (payload.data || [])
+    .map((model) => model.id)
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b))
+
+  if (!models.length) {
+    throw new Error('No models returned. Enter a model name manually.')
+  }
+
+  return models
+}
+
+export async function readErrorMessage(response) {
+  try {
+    const payload = await response.json()
+    return payload?.error?.message || response.statusText
+  } catch {
+    return response.statusText
+  }
+}

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -35,4 +35,5 @@ export default defineManifest({
     },
   ],
   permissions: ['storage'],
+  optional_host_permissions: ['<all_urls>'],
 })

--- a/src/popup/index.css
+++ b/src/popup/index.css
@@ -80,7 +80,9 @@ label {
 }
 
 /* Form elements */
-input[type="password"],
+input[type='password'],
+input[type='text'],
+input[type='url'],
 select {
   width: 100%;
   padding: var(--spacing-small) var(--spacing-medium);
@@ -90,15 +92,26 @@ select {
   transition: border-color var(--transition-duration) ease;
 }
 
-input[type="password"].error {
+input.error {
   border-color: var(--color-error);
   box-shadow: 0 0 0 2px rgba(255, 65, 54, 0.2);
 }
 
-input[type="password"]:focus,
+input[type='password']:focus,
+input[type='text']:focus,
+input[type='url']:focus,
 select:focus {
   border-color: var(--color-link);
   outline: none;
+}
+
+#customModel {
+  margin-top: var(--spacing-small);
+}
+
+.hint {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-small);
 }
 
 /* Links */
@@ -113,8 +126,19 @@ select:focus {
   transition: color var(--transition-duration) ease;
 }
 
-.link:hover {
+.link:hover,
+.link-button:hover {
   color: var(--color-link-hover);
+}
+
+.link-button {
+  appearance: none;
+  background: none;
+  border: 0;
+  color: var(--color-link);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
 }
 
 /* Buttons */
@@ -131,8 +155,9 @@ select:focus {
   padding: 10px 16px;
   font-size: var(--font-size-regular);
   cursor: pointer;
-  transition: background-color var(--transition-duration) ease,
-              transform 0.1s ease;
+  transition:
+    background-color var(--transition-duration) ease,
+    transform 0.1s ease;
 }
 
 .action-button:hover {

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -1,10 +1,19 @@
 import './index.css'
+import { RUNTIME_MESSAGES } from '../lib/constants.js'
+import {
+  DEFAULT_OPENAI_BASE_URL,
+  getBaseUrlPermissionOrigin,
+  normalizeBaseUrl,
+} from '../lib/openaiCompatibleApi.js'
 
 document.addEventListener('DOMContentLoaded', function () {
   const hiddenKey = '********'
 
   const apiKeyInput = document.getElementById('apiKey')
+  const baseUrlInput = document.getElementById('baseUrl')
   const modelSelect = document.getElementById('modelSelect')
+  const customModelInput = document.getElementById('customModel')
+  const detectModelsButton = document.getElementById('detectModels')
   const saveButton = document.getElementById('save')
   const clearButton = document.getElementById('clear')
   const statusMessage = document.getElementById('status')
@@ -23,17 +32,48 @@ document.addEventListener('DOMContentLoaded', function () {
 
   checkAndHighlightApiKey()
 
-  chrome.storage.local.get('openaiModel', function (result) {
-    if (result.openaiModel) {
-      modelSelect.value = result.openaiModel
-    }
-  })
+  chrome.storage.local.get(
+    ['openaiModel', 'openaiBaseUrl', 'openaiCustomModel', 'openaiDetectedModels'],
+    function (result) {
+      baseUrlInput.value = result.openaiBaseUrl || DEFAULT_OPENAI_BASE_URL
+      updateModelOptions(result.openaiDetectedModels || [], result.openaiModel)
 
-  saveButton.addEventListener('click', function () {
+      if (result.openaiModel) {
+        modelSelect.value = result.openaiModel
+      }
+
+      if (result.openaiCustomModel) {
+        customModelInput.value = result.openaiCustomModel
+      }
+    },
+  )
+
+  saveButton.addEventListener('click', async function () {
     const apiKey = apiKeyInput.value
-    const selectedModel = modelSelect.value
+    const customModel = customModelInput.value.trim()
+    const selectedModel = customModel || modelSelect.value
+    let baseUrl
 
-    const propsToSave = { openaiModel: selectedModel }
+    try {
+      baseUrl = normalizeBaseUrl(baseUrlInput.value)
+    } catch (error) {
+      baseUrlInput.classList.add('error')
+      statusMessage.textContent = error.message
+      return
+    }
+
+    try {
+      await requestBaseUrlPermission(baseUrl)
+    } catch (error) {
+      statusMessage.textContent = error.message
+      return
+    }
+
+    const propsToSave = {
+      openaiBaseUrl: baseUrl,
+      openaiModel: selectedModel,
+      openaiCustomModel: customModel,
+    }
     if (apiKey !== hiddenKey) {
       propsToSave.openaiApiKey = apiKey
     }
@@ -52,18 +92,170 @@ document.addEventListener('DOMContentLoaded', function () {
   })
 
   clearButton.addEventListener('click', function () {
-    chrome.storage.local.remove(['openaiApiKey', 'openaiModel'], function () {
-      apiKeyInput.value = ''
-      modelSelect.value = 'gpt-4o-mini'
-      statusMessage.textContent = 'Settings cleared!'
-      checkAndHighlightApiKey()
+    chrome.storage.local.remove(
+      ['openaiApiKey', 'openaiModel', 'openaiBaseUrl', 'openaiCustomModel', 'openaiDetectedModels'],
+      function () {
+        apiKeyInput.value = ''
+        baseUrlInput.value = DEFAULT_OPENAI_BASE_URL
+        updateModelOptions([], 'gpt-4o-mini')
+        customModelInput.value = ''
+        statusMessage.textContent = 'Settings cleared!'
+        checkAndHighlightApiKey()
+        setTimeout(() => {
+          statusMessage.textContent = ''
+        }, 2000)
+      },
+    )
+  })
+
+  detectModelsButton.addEventListener('click', async function () {
+    const apiKey = await getApiKeyForRequest(apiKeyInput.value, hiddenKey)
+    let baseUrl
+
+    try {
+      baseUrl = normalizeBaseUrl(baseUrlInput.value)
+    } catch (error) {
+      baseUrlInput.classList.add('error')
+      statusMessage.textContent = error.message
+      return
+    }
+
+    if (!apiKey) {
+      apiKeyInput.classList.add('error')
+      statusMessage.textContent = 'Enter an API key before detecting models.'
+      return
+    }
+
+    try {
+      await requestBaseUrlPermission(baseUrl)
+    } catch (error) {
+      statusMessage.textContent = error.message
+      return
+    }
+
+    detectModelsButton.setAttribute('disabled', true)
+    statusMessage.textContent = 'Detecting models...'
+
+    try {
+      const models = await detectModels(apiKey, baseUrl)
+      updateModelOptions(models, models[0])
+      chrome.storage.local.set({
+        openaiBaseUrl: baseUrl,
+        openaiDetectedModels: models,
+        openaiModel: modelSelect.value,
+        openaiCustomModel: '',
+      })
+      customModelInput.value = ''
+      statusMessage.textContent = `Detected ${models.length} model${models.length === 1 ? '' : 's'}.`
+    } catch (error) {
+      statusMessage.textContent = error.message
+    } finally {
+      detectModelsButton.removeAttribute('disabled')
       setTimeout(() => {
         statusMessage.textContent = ''
-      }, 2000)
-    })
+      }, 3000)
+    }
   })
 
   apiKeyInput.addEventListener('input', function () {
     apiKeyInput.classList.remove('error')
   })
+
+  baseUrlInput.addEventListener('input', function () {
+    baseUrlInput.classList.remove('error')
+  })
 })
+
+function updateModelOptions(detectedModels, selectedModel) {
+  const modelSelect = document.getElementById('modelSelect')
+  const defaultModels = [
+    ['gpt-4o-mini', 'GPT-4o Mini (Recommended)'],
+    ['gpt-4o', 'GPT-4o'],
+    ['o1-preview', 'O1 Preview'],
+    ['o1-mini', 'O1 Mini'],
+    ['gpt-3.5-turbo', 'GPT-3.5 Turbo'],
+  ]
+  const models = detectedModels.length
+    ? detectedModels.map((model) => [model, model])
+    : defaultModels
+
+  modelSelect.textContent = ''
+  models.forEach(([value, label]) => {
+    const option = document.createElement('option')
+    option.value = value
+    option.textContent = label
+    modelSelect.appendChild(option)
+  })
+
+  if (selectedModel && [...modelSelect.options].some((option) => option.value === selectedModel)) {
+    modelSelect.value = selectedModel
+  }
+}
+
+function requestBaseUrlPermission(baseUrl) {
+  if (!chrome.permissions) {
+    return Promise.resolve()
+  }
+
+  const permission = { origins: [getBaseUrlPermissionOrigin(baseUrl)] }
+  return new Promise((resolve, reject) => {
+    chrome.permissions.contains(permission, (hasPermission) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message))
+        return
+      }
+
+      if (hasPermission) {
+        resolve()
+        return
+      }
+
+      chrome.permissions.request(permission, (granted) => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message))
+        } else if (granted) {
+          resolve()
+        } else {
+          reject(new Error(`Permission is required to access ${permission.origins[0]}.`))
+        }
+      })
+    })
+  })
+}
+
+function getApiKeyForRequest(apiKeyInputValue, hiddenKey) {
+  if (apiKeyInputValue && apiKeyInputValue !== hiddenKey) {
+    return Promise.resolve(apiKeyInputValue)
+  }
+
+  return new Promise((resolve) => {
+    chrome.storage.local.get('openaiApiKey', (result) => {
+      resolve(result.openaiApiKey || '')
+    })
+  })
+}
+
+function detectModels(apiKey, baseUrl) {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage(
+      {
+        type: RUNTIME_MESSAGES.detectModels,
+        apiKey,
+        baseUrl,
+      },
+      (response) => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message))
+          return
+        }
+
+        if (response?.type === RUNTIME_MESSAGES.detectModels) {
+          resolve(response.models)
+          return
+        }
+
+        reject(new Error(response?.message || 'Could not detect models.'))
+      },
+    )
+  })
+}


### PR DESCRIPTION
## Summary

This PR adds support for OpenAI-compatible API providers and updates the extension for Garmin's newer workout pages.

Main changes:

- Add a configurable API Base URL, defaulting to `https://api.openai.com/v1`
- Allow custom model names
- Add model detection via the `/models` endpoint
- Replace the OpenAI SDK call with a direct `/chat/completions` request for broader provider compatibility
- Add compatibility retries for providers/models that reject optional parameters such as `temperature`, `max_tokens`, `max_output_tokens`, or require a top-level `instructions` field
- Improve error handling for generation and Garmin upload failures
- Update Garmin Connect support for the newer `/app/workouts` page and `gc-api` workout endpoint
- Add tests for custom base URLs, model response parsing, unsupported-parameter retries, and Garmin payload fallbacks

## Why

Many users access OpenAI-compatible models through relay providers, self-hosted gateways, or third-party API-compatible services. The previous implementation was tied to the official OpenAI SDK and default OpenAI endpoint, which made these setups difficult or impossible to use.

This PR keeps the official OpenAI API as the default while making the provider endpoint and model name configurable, and it also restores compatibility with Garmin's newer workout page.

## Verification

- `npx jest --runInBand --detectOpenHandles`
- `npm run lint`
- `npm run build`